### PR TITLE
Composer, namespaces, autoloader et plus...

### DIFF
--- a/actions/__include.php
+++ b/actions/__include.php
@@ -1,49 +1,25 @@
 <?php
+namespace Lang;
+
+$loader = require __DIR__ . '/../vendor/autoload.php';
+
 if (!defined("WIKINI_VERSION"))
 {
     die ("acc&egrave;s direct interdit");
 }
 
+$includedpage = $this->LoadPage(trim($this->GetParameter('page')));
 
-// Affichage uniquement du contenu correspondant à la langue en cours
-$translation_found=false;
-
-$includedpage=$this->LoadPage(trim($this->GetParameter('page')));
-
-$chunks = preg_split(
-    "/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/ms",
-    $this->page["body"],
-    -1,
-    PREG_SPLIT_DELIM_CAPTURE
+$lang = new Lang(
+    $includedpage["body"],
+    $GLOBALS['prefered_language']
 );
 
-// DEBUG
-print("<pre>");
-print_r($chunks);
-print("</pre>");
+if (!isset($_GET['lang'])) {
+    $_GET['lang'] = $GLOBALS['prefered_language'];
+}
 
-if (count($chunks) > 1) {
-
-    for ($t=1;$t<count($chunks);$t=$t+2) {
-        if (preg_match("/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/",$chunks[$t],$lang_to_display)) {
-          if ($lang_to_display[1]==$GLOBALS['prefered_language']) {
-            $includedpage["body"]=$chunks[$t+1];
-            $translation_found=true;
-          }
-        }
-    }
-    if (!$translation_found) {  // Pas de traduction ? Affichage de la langue par defaut
-		for ($t=1;$t<count($chunks);$t=$t+2) {
-			if (preg_match("/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/",$chunks[$t],$lang_to_display)) {
-			  if ($lang_to_display[1]==$this->config['default_language']) {
-			    $includedpage["body"]=$chunks[$t+1];
-			  }
-			}
-		}
-    }
+$includedpage["body"] = $lang->get($_GET['lang']);
 
 // Hack : mise a jour du cache avec la nouvelle version.
-	$this->CachePage($includedpage);
-
-}
-?>
+$this->CachePage($includedpage);

--- a/actions/lang.php
+++ b/actions/lang.php
@@ -1,11 +1,9 @@
 <?php
 
-// TODO : a basculer dans __show.php
-// Vérification de sécurité
 if (!defined("WIKINI_VERSION"))
 {
-  die ("acc&egrave;s direct interdit");
+    die ("acc&egrave;s direct interdit");
 }
 
-
-?>
+// Ne fais rien, sert  uniquement à éviter un message d'erreur concernant une
+// action inexistante

--- a/actions/translation.php
+++ b/actions/translation.php
@@ -3,7 +3,7 @@
 // TODO : a basculer dans __show.php
 // Vérification de sécurité
 if (!defined("WIKINI_VERSION")) {
-    die("acc&egrave;s direct interdit");
+    die("accès direct interdit");
 }
 
 $destination = $this->GetParameter("destination");
@@ -12,6 +12,7 @@ if (empty($destination)) {
 }
 
 $wikireq = $_REQUEST['wiki'];
+
 // remove leading slash
 $wikireq = preg_replace("/^\//", "", $wikireq);
 // split into page/method, checking wiki name & method name (XSS proof)
@@ -25,8 +26,9 @@ if (preg_match('`^' . '(' . "[A-Za-z0-9]+" . ')/(' . "[A-Za-z0-9_-]" . '*)' . '$
 $flagfile='tools/lang/presentation/images/'.$destination.'.png';
 
 if (file_exists($flagfile)) {
-    echo '<a href="wakka.php?wiki='.$PageTag.'&lang='.$destination.'">
-        <img src="'.$flagfile.'" title="'.$destination.'" alt="Flag'.$destination.'"></img></a>';
+    echo "<a href=\"wakka.php?wiki=$PageTag&lang=$destination\">"
+        . "<img src=\"$flagfile\" title=\"$destination\" alt=\"Flag$destination\"></img>"
+        . "</a>";
 } else {
-    echo _t(LANG_FLAG_FILE_MISSING);
+    echo "<a href=\"wakka.php?wiki=$PageTag&lang=$destination\">$destination</a>";
 }

--- a/actions/translation.php
+++ b/actions/translation.php
@@ -1,14 +1,11 @@
 <?php
+namespace Lang;
 
-// TODO : a basculer dans __show.php
-// Vérification de sécurité
-if (!defined("WIKINI_VERSION")) {
-    die("accès direct interdit");
-}
+$loader = require __DIR__ . '/../vendor/autoload.php';
 
-$destination = $this->GetParameter("destination");
-if (empty($destination)) {
-    echo _t(LANG_DESTINATION_REQUIRED);
+if (!defined("WIKINI_VERSION"))
+{
+    die("acc&egrave;s direct interdit");
 }
 
 $wikireq = $_REQUEST['wiki'];
@@ -17,18 +14,29 @@ $wikireq = $_REQUEST['wiki'];
 $wikireq = preg_replace("/^\//", "", $wikireq);
 // split into page/method, checking wiki name & method name (XSS proof)
 if (preg_match('`^' . '(' . "[A-Za-z0-9]+" . ')/(' . "[A-Za-z0-9_-]" . '*)' . '$`', $wikireq, $matches)) {
-    list(, $PageTag, $method) = $matches;
+    list(, $pageTag, $method) = $matches;
 } elseif (preg_match('`^' . "[A-Za-z0-9]+" . '$`', $wikireq)) {
-    $PageTag = $wikireq;
+    $pageTag = $wikireq;
 }
-// Todo : utiliser template
 
-$flagfile='tools/lang/presentation/images/'.$destination.'.png';
+$page = $this->LoadPage($pageTag);
 
-if (file_exists($flagfile)) {
-    echo "<a href=\"wakka.php?wiki=$PageTag&lang=$destination\">"
-        . "<img src=\"$flagfile\" title=\"$destination\" alt=\"Flag$destination\"></img>"
-        . "</a>";
-} else {
-    echo "<a href=\"wakka.php?wiki=$PageTag&lang=$destination\">$destination</a>";
+$lang = new Lang(
+    $page["body"],
+    $GLOBALS['prefered_language']
+);
+
+$listLang = $lang->getLangList();
+
+$output = "";
+foreach ($listLang as $lang) {
+    $output .= "<a href=\"?wiki=$pageTag&lang=$lang\">";
+    $text = $lang;
+    $flagFile = 'tools/lang/presentation/images/'.$lang.'.png';
+    if (file_exists($flagFile)) {
+        $text = "<img src=\"$flagFile\" title=\"$lang\" alt=\"Flag$lang\"></img>";
+    }
+    $output .= "$text</a> ";
 }
+
+echo($output);

--- a/app/Lang.php
+++ b/app/Lang.php
@@ -1,0 +1,86 @@
+<?php
+namespace Lang;
+
+/**
+ * @author   Florestan Bredow <florestan.bredow@supagro.fr>
+ * @license
+ */
+class Lang
+{
+
+    private $chunks = array();
+    private $defaultLanguage;
+
+    /**
+     * Constructeur
+     */
+    public function __construct($pageContent, $defaultLanguage = "en")
+    {
+        $this->chunks = $this->cut($pageContent);
+        $this->defaultLanguage = $defaultLanguage;
+    }
+
+    /**
+     * renvois le contenu de la page dans la langue demandé, ou la langue par
+     * défaut si la langue demandée n'est pas disponible.
+     *
+     * @param  string $lang code pays (fr, en, es, hu...)
+     * @return [type]       [description]
+     */
+    public function get($lang)
+    {
+        // Si la langue demandée n'existe pas,
+        // la langue par défaut est retournée
+        if (!array_key_exists($lang, $this->chunks)) {
+            $lang = $this->defaultLanguage;
+            // Si la langue par défaut n'existe pas, la premiere langue
+            // disponible est renvoyée.
+            if (!array_key_exists($lang)) {
+                reset($this->chunks);
+                $lang = array_keys($this->chunks)[0];
+            }
+        }
+        return $this->chunks[$lang];
+    }
+
+    /**
+     * Découpe le contenu dans un tableau type :
+     *  array(
+     *      "code_langue" => "texte,
+     *      "code_langue" => "texte,
+     *      ...
+     *  )
+     * @param  $string $pageContent contenu de la page a traiter.
+     * @return [type]              [description]
+     */
+    private function cut($pageContent)
+    {
+        // Dans le cas ou aucune {{lang="XX"}} n'est spécifiée.
+        if (!preg_match("/{{lang=\"[a-zA-Z][a-zA-Z]\"}}/", $pageContent)) {
+            return array($this->defaultLanguage => $pageContent);
+        }
+
+        // Supprime tout avant la première occurence de l'action lang
+        $pageContent = strstr($pageContent, "{{lang=\"");
+
+        $chunkedContent =  preg_split(
+            "/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/ms",
+            $pageContent,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+        );
+
+        // Réorganise le tableau, les valeurs paires deviennent les clés et les
+        // valeurs impaires la valeur.
+        $result = array();
+        foreach ($chunkedContent as $key => $value) {
+            // Ignore les clés impaires
+            if ($key % 2 != 0) {
+                continue;
+            }
+            $result[$value] = trim($chunkedContent[$key + 1]);
+        }
+        return $result;
+    }
+
+}

--- a/app/Lang.php
+++ b/app/Lang.php
@@ -43,6 +43,11 @@ class Lang
         return $this->chunks[$lang];
     }
 
+    public function getLangList()
+    {
+        return array_keys($this->chunks);
+    }
+
     /**
      * Découpe le contenu dans un tableau type :
      *  array(

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "yeswiki/lang",
+    "description": "Extension pour gérer les pages multilangues",
+    "type": "extension",
+    "license": "GPL3",
+    "authors": [
+        {
+            "name": "Florestan Bredow",
+            "email": "florestan.bredow@supagro.fr"
+        },
+        {
+            "name": "David Delon"
+        }
+    ],
+    "require": {},
+    "autoload": {
+        "psr-4": {
+          "Lang\\": "app"
+        }
+    }
+}

--- a/handlers/page/__show.php
+++ b/handlers/page/__show.php
@@ -1,34 +1,20 @@
 <?php
-/*
-*/
+namespace Lang;
+
 if (!defined("WIKINI_VERSION"))
 {
-            die ("acc&egrave;s direct interdit");
+    die ("Accés direct interdit");
 }
 
+$loader = require __DIR__ . '/../../vendor/autoload.php';
 
-// Affichage uniquement du contenu correspondant à la langue en cours
- $translation_found=false;
- if (count($chunks=preg_split("/({{lang=\"[a-zA-Z][a-zA-Z]*\"}})/ms",$this->page["body"],-1,PREG_SPLIT_DELIM_CAPTURE))>1) {
-    for ($t=1;$t<count($chunks);$t=$t+2) {
-        if (preg_match("/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/",$chunks[$t],$lang_to_display)) {
-          if ($lang_to_display[1]==$GLOBALS['prefered_language']) {
-            $this->page["body"]=$chunks[$t+1];
-            $translation_found=true;
-          }
-        }
-    }
+$lang = new Lang(
+    $this->page["body"],
+    $GLOBALS['prefered_language']
+);
 
-    if (!$translation_found) {  // Pas de traduction ? Affichage de la langue par defaut
-      for ($t=1;$t<count($chunks);$t=$t+2) {
-        if (preg_match("/{{lang=\"([a-zA-Z][a-zA-Z])*\"}}/",$chunks[$t],$lang_to_display)) {
-          if ($lang_to_display[1]== $this->config['default_language']) {
-              $this->page["body"]=$chunks[$t+1];
-          }
-        }
-      }
-    }
-  }
+if (!isset($_GET['lang'])) {
+    $_GET['lang'] = $GLOBALS['prefered_language'];
+}
 
-
-?>
+$this->page["body"] = $lang->get($_GET['lang']);

--- a/index.php
+++ b/index.php
@@ -3,9 +3,5 @@
 
 if (!defined("TOOLS_MANAGER"))
 {
-        die ("acc&egrave;s direct interdit");
+    die ("acc&egrave;s direct interdit");
 }
-
-
-
-?>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="Rule set for phpmd"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        My custom rule set that checks my code...
+    </description>
+    <rule ref="rulesets/cleancode.xml" />
+    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/design.xml" />
+    <rule ref="rulesets/naming.xml" />
+    <rule ref="rulesets/controversial.xml" />
+    <rule ref="rulesets/unusedcode.xml" />
+</ruleset>

--- a/wiki.php
+++ b/wiki.php
@@ -4,27 +4,26 @@ if (!defined("WIKINI_VERSION")) {
     die ("acc&egrave;s direct interdit");
 }
 
-  
-
 $wikiClasses [] = 'lang';
-$wikiClassesContent [] = ' 
+$wikiClassesContent [] = '
 
 function Href($method = "", $tag = "", $params = "", $htmlspchars = true) {
 
-    if (!$tag = trim($tag)) $tag = $this->tag;
-        $href = $this->config["base_url"].$this->MiniHref($method, $tag);
+    if (!$tag = trim($tag)) {
+        $tag = $this->tag;
+    }
+
+    $href = $this->config["base_url"] . $this->MiniHref($method, $tag);
+
     if ($params) {
         $href .= ($this->config["rewrite_mode"] ? "?" : ($htmlspchars ? "&amp;" : "&")).$params;
     }
-    if (isset($_GET[\'lang\']) && $_GET[\'lang\']!="") {
-    	$href .= "&lang='.$GLOBALS["prefered_language"].'";
+
+    if (isset($_GET[\'lang\']) and $_GET[\'lang\']!="") {
+    	$href .= "&lang=' . $GLOBALS["prefered_language"]. '";
     }
-    
+
     return $href;
-}    
+}
 
-
-';		
-
-
-?>
+';


### PR DESCRIPTION
- Usage de composer pour les autoloaders
- Factorisation du code
- N'affiche que les drapeaux des lanques disponibles (rien si l'action lang n'est pas utilisée)
- Compatibilité avec la dernière version de YesWiki
